### PR TITLE
Add specific outro selection in config

### DIFF
--- a/static/data/config.yaml
+++ b/static/data/config.yaml
@@ -160,10 +160,16 @@ walks:
   
   language:
     walk-arabic:
+      intro: wait-arabic
     walk-danish:
+      intro: wait-danish
     walk-german:
+      intro: wait-german
     walk-japanese:
+      intro: wait-japanese
     walk-mandarin-taiwan:
+      intro: wait-mandarin-taiwan
+      outro: countdown-mandarin-taiwan
   
   normal:
     walk:

--- a/static/data/img/outros/countdown-mandarin-taiwan.gif
+++ b/static/data/img/outros/countdown-mandarin-taiwan.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e87f5ebaf55f2403882bc2e9a1076c8c88068ed98c033b882cba4f96fee81b75
+size 70298

--- a/static/data/img/walks/walk-mandarin-taiwan.gif
+++ b/static/data/img/walks/walk-mandarin-taiwan.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e87f5ebaf55f2403882bc2e9a1076c8c88068ed98c033b882cba4f96fee81b75
-size 70298
+oid sha256:4a1341d4be437b76d900f33a3133bd178370ba4e83b2aa560f317679e8353113
+size 12389

--- a/static/data/snd/countdown-mandarin-taiwan.mp3
+++ b/static/data/snd/countdown-mandarin-taiwan.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6734eb7f687b16ae65d1351a1d548d538b56c5d79debbe866f93925f52f47c0
+size 15745

--- a/static/data/snd/walk-mandarin-taiwan.mp3
+++ b/static/data/snd/walk-mandarin-taiwan.mp3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:32d81587dd4e71234b93eea801dabdcdb3ea99a041bdb85befe8b1452bfd5578
-size 123864
+oid sha256:d9833b156cea5df5dfd54ba6c9053b7df951e526e839babaa9ce21c497c94b4d
+size 15554

--- a/xwalk2/animation_library.py
+++ b/xwalk2/animation_library.py
@@ -74,22 +74,12 @@ class AnimationLibrary:
         # No active schedule; fallback to demo or default.
         return weights
 
-    def select_intro(self, walk: Optional[str] = None) -> str:
+    def select_intro(self) -> str:
         """
         Select a random* intro animation with even distribution
-
-        * Not random, if we are selecting the intro based on a given walk.
         """
-        # If the walk starts with "walk-" then we need to select an intro that
-        # matches the walk name except instead of "walk" it says "wait" e.g.
-        # "walk-danish" -> "wait-danish"
-        if walk and walk.startswith("walk-"):
-            # Matching intros should have the same name as the walk except
-            # instead of "walk" it says "wait" e.g. "walk-danish" -> "wait-danish"
-            return walk.replace("walk-", "wait-")
-        else:
-            # Random selection with even distribution
-            return str(np.random.choice(self.config.intros))
+        # Random selection with even distribution
+        return str(np.random.choice(self.config.intros))
 
     def select_walk(self, weights: Optional[WeightSchedule] = None) -> Tuple[str, str]:
         """Select a random walk animation based on current weights"""
@@ -234,8 +224,21 @@ class AnimationLibrary:
         category = None
         if not walk:
             walk, category = self.select_walk(weights=weights)
-        intro = self.select_intro(walk)
+       
+        # choose default intro and outro
+        intro = self.select_intro()
         outro = self.select_outro()
+
+        # Check whether we should be using a custom intro and outro
+        # and update if so
+        walk_info = self.config.get_walk(walk)
+        if walk_info:
+            intro = walk_info.intro or self.select_intro()
+            outro = walk_info.outro or self.select_outro()
+            audio_walk = walk_info.audio or walk
+        else:
+            audio_walk = walk
+        
         logger.info(f"selected {intro=} {walk=} {outro=}")
 
         audio_intro = intro

--- a/xwalk2/matrix_driver.py
+++ b/xwalk2/matrix_driver.py
@@ -86,7 +86,7 @@ class MatrixViewer(SubscribeComponent):
         command = self._display_command(animation.image, shell=False, forever=True)
         # command = " ".join(command)
 
-        logger.info("Playing: %s", animation)
+        logger.info("Playing: %s", animation.image)
         self._exec(command)
         self._playing = [animation.image]
 
@@ -124,7 +124,7 @@ class MatrixViewer(SubscribeComponent):
 
         script = " && ".join(commands)
 
-        logger.info("Playing all: %s", animations)
+        logger.info("Playing all: %s", [a.image for a in animations])
         logger.debug("Script: %s", script)
         self._exec(script, shell=True)
         self._playing = [a.image for a in animations]

--- a/xwalk2/matrix_driver_virtual.py
+++ b/xwalk2/matrix_driver_virtual.py
@@ -13,7 +13,7 @@ import argparse
 import logging
 
 from xwalk2.util import Heartbeat, add_default_args
-from xwalk2.models import CurrentState, EndScene, PlayScene, ResetCommand, parse_message
+from xwalk2.models import CurrentState, EndScene, PlayScene, ResetCommand, parse_message, WalkDefinition
 
 
 # Constants
@@ -181,9 +181,9 @@ class MatrixDisplay:
         )
         self.animation_thread.start()
     
-    def play_scene_sequence(self, intro: str, walk: str, outro: str):
+    def play_scene_sequence(self, intro: WalkDefinition, walk: WalkDefinition, outro: WalkDefinition):
         """Play a complete animation sequence"""
-        logging.info(f"🎬 Playing sequence: {intro} -> {walk} -> {outro}")
+        logging.info(f"🎬 Playing sequence: {intro.image} -> {walk.image} -> {outro.image}")
         
         if self.animation_thread and self.animation_thread.is_alive():
             self.stop_event.set()
@@ -238,19 +238,19 @@ class MatrixDisplay:
                 if self.stop_event.is_set():
                     return
     
-    def _sequence_worker(self, intro: str, walk: str, outro: str):
+    def _sequence_worker(self, intro: WalkDefinition, walk: WalkDefinition, outro: WalkDefinition):
         """Worker thread for animation sequence"""
         sequence = [intro, walk, outro]
-        sequence_names = ["intro", "walk", "outro"]
         
         for anim_name in sequence:
             if self.stop_event.is_set():
                 return
             
             # Load animation just-in-time, not pre-loaded
-            frames, durations = self.gif_player.load_gif(anim_name)
+            frames, durations = self.gif_player.load_gif(anim_name.image)
             
-            for frame_idx, (frame, duration) in enumerate(zip(frames, durations)):
+            # Play each frame of the current animation
+            for frame, duration in zip(frames, durations):
                 if self.stop_event.is_set():
                     return
                 

--- a/xwalk2/models.py
+++ b/xwalk2/models.py
@@ -36,6 +36,8 @@ class WalkDefinition(BaseModel):
 
 class WalkInfo(BaseModel):
     audio: Optional[str] = None
+    intro: Optional[str] = None
+    outro: Optional[str] = None
     ignore_reselection: bool = False
 
 


### PR DESCRIPTION
Makes it so we can override intro and outro by defining them in the config (as opposed to what we were previously doing for intros which was hard coding special handling for language walks into the animation library).